### PR TITLE
Minor fixes

### DIFF
--- a/src/ninja-header.js
+++ b/src/ninja-header.js
@@ -57,7 +57,8 @@ export class NinjaHeader extends BaseElement {
       }
 
       .breadcrumb:focus-visible {
-        background-color: red;
+        background-color: var(--ninja-selected-background);
+        color: var(--ninja-secondary-text-color);
       }
 
       .breadcrumb:last-child {

--- a/src/ninja-keys.js
+++ b/src/ninja-keys.js
@@ -410,12 +410,12 @@ export class NinjaKeys extends BaseElement {
    * @param {import("lit").PropertyValues<this>} changedProperties
    */
   update(changedProperties) {
-    if (changedProperties.has('data') && !this.disableHotkeys) {
+    if (changedProperties.has('data')) {
       this._flatData = this._flattern(this.data);
 
-      this._flatData
-        .forEach((action) => {
-          if (!action.hotkey) return
+      if (!this.disableHotkeys) {
+        this._flatData.forEach((action) => {
+          if (!action.hotkey) return;
 
           hotkeys(action.hotkey, (event) => {
             event.preventDefault();
@@ -424,6 +424,7 @@ export class NinjaKeys extends BaseElement {
             }
           });
         });
+      }
     }
     super.update(changedProperties);
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,3 +22,7 @@ export interface ISearchOptions {
   searchString: string;
   searchRegex: RegExp;
 }
+
+export interface INinjaActionData extends Omit<INinjaAction, 'children'> {
+  children?: (INinjaActionData | string)[];
+}


### PR DESCRIPTION
Hi @KonnorRogers 

Thank you for the great work.

This PR fixes some issues as discussed here: #17 

- The `.breadcrumb:focus-visible` had a red background.
- When `disableHotkeys` is enabled, the command menu would be empty. 
- Items listed after an item with children were not displayed.

I have a question:
I have my editor configured to run prettier formatter on save. When I do, lots of formatting changes occur.
I tried running the [npm script `format`](https://github.com/KonnorRogers/konnors-ninja-keys/blob/a95114e9945226664e4a17aded86175920a7b584/package.json#L48), and lots of changes occured in many files.
I suggest commiting this, so that later contributions would be focused on the actual code changes. Do you want me to do this in this PR, or do you want to do that yourself later?

Closes #17 