### PR TITLE
add "Preview in LiveCodes" github actions

### DIFF
--- a/.github/workflows/livecodes-post-comment.yml
+++ b/.github/workflows/livecodes-post-comment.yml
@@ -1,0 +1,21 @@
+name: comment
+
+on:
+  workflow_run:
+    workflows: ['livecodes'] # the workflow that created the artifact
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - uses: live-codes/pr-comment-from-artifact@v1
+        with:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/livecodes-preview.yml
+++ b/.github/workflows/livecodes-preview.yml
@@ -1,0 +1,17 @@
+name: livecodes
+
+on: [pull_request]
+
+jobs:
+  build_and_prepare:
+    runs-on: ubuntu-latest
+    name: Generate Playgrounds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build and generate
+        uses: live-codes/preview-in-livecodes@v1
+        with:
+          install-command: 'npm install'
+          build-command: 'npm run build'

--- a/.github/workflows/livecodes-preview.yml
+++ b/.github/workflows/livecodes-preview.yml
@@ -7,8 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate Playgrounds
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            docs/pnpm-lock.yaml
 
       - name: Build and generate
         uses: live-codes/preview-in-livecodes@v1

--- a/.github/workflows/livecodes-preview.yml
+++ b/.github/workflows/livecodes-preview.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Build and generate
         uses: live-codes/preview-in-livecodes@v1
         with:
-          install-command: 'npm install'
-          build-command: 'npm run build'
+          install-command: 'pnpm install'
+          build-command: 'pnpm build'

--- a/.livecodes/esm.json
+++ b/.livecodes/esm.json
@@ -1,0 +1,24 @@
+{
+  "title": "Static HTML/JS",
+  "activeEditor": "script",
+  "markup": {
+    "language": "html",
+    "content": "<link rel=\"preconnect\" href=\"https://fonts.gstatic.com/\" crossorigin />\n<link rel=\"preload\" href=\"https://fonts.googleapis.com/css?family=Inter:300,400,500\" as=\"style\" type=\"text/css\" />\n<link href=\"https://fonts.googleapis.com/css?family=Inter&display=swap\" rel=\"stylesheet\" />\n<link href=\"https://fonts.googleapis.com/css?family=Material+Icons&display=swap\" rel=\"stylesheet\" />\n<ninja-keys></ninja-keys>\n<button id=\"search\">Ctrl + K</button>\n"
+  },
+  "style": {
+    "language": "css",
+    "content": "html, body {\n  display: flex;\n  align-items: center;\n  justify-content: center;\n  height: 100%;\n  width: 100%;\n}\n\n#search {\n  font-family: sans-serif;\n  padding: 1em;\n  background-color: #eee;\n  border: 1px solid #ccc;\n  border-radius: 0.5em;\n  cursor: pointer;\n}\n\nninja-keys {\n  font-family: Inter, system-ui, sans-serif;\n}\n"
+  },
+  "script": {
+    "language": "javascript",
+    "content": "import 'konnors-ninja-keys';\n\nconst ninja = document.querySelector('ninja-keys');\nninja.data = [\n  {\n    id: 'Projects',\n    title: 'Open Projects',\n    hotkey: 'ctrl+N',\n    mdIcon: 'apps',\n    section: 'Projects',\n    handler: (_data, _event) => {\n      alert('Your logic to handle');\n    },\n  },\n  {\n    id: 'Theme',\n    title: 'Change theme...',\n    mdIcon: 'desktop_windows',\n    children: ['Light Theme', 'Dark Theme', 'System Theme'],\n    hotkey: 'ctrl+T',\n    handler: () => {\n      ninja.open({ parent: 'Theme' });\n      return { keepOpen: true };\n    },\n  },\n  {\n    id: 'Light Theme',\n    title: 'Change theme to Light',\n    mdIcon: 'light_mode',\n    parent: 'Theme',\n    handler: () => {\n      ninja.classList.remove('dark');\n      return { keepOpen: true };\n    },\n  },\n  {\n    id: 'Dark Theme',\n    title: 'Change theme to Dark',\n    mdIcon: 'dark_mode',\n    parent: 'Theme',\n    handler: () => {\n      ninja.classList.add('dark');\n      return { keepOpen: true };\n    },\n  },\n];\n\ndocument.querySelector('#search').addEventListener('click', () => {\n  ninja.open();\n});\n"
+  },
+  "customSettings": {
+    "imports": {
+      "konnors-ninja-keys": "{{LC::TO_DATA_URL(./bundle/all.js)}}"
+    },
+    "types": {
+      "racing-bars": "{{LC::TO_DATA_URL(./types/index.d.ts)}}"
+    }
+  }
+}


### PR DESCRIPTION
Hi @KonnorRogers 

This PR adds the feature of posting a comment for every push to PR with preview links in [LiveCodes](https://livecodes.io/) (as discussed in #23 ), using the ["Preview in LiveCodes"](https://github.com/live-codes/preview-in-livecodes) GitHub action.

This is a screenshot from [racing-bars](https://github.com/hatemhosny/racing-bars/pull/203#issuecomment-2337598946) repo.

![image](https://github.com/user-attachments/assets/f28f9a57-3712-4e55-b7df-6a385666906d)

3 files are added:

- `.github\workflows\livecodes-preview.yml`: builds the library and save the artifacts.
- `.github\workflows\livecodes-post-comment.yml`: posts the playground links as PR comments.
- `.livecodes\esm.json`: adds a sample project with the code you want in the playground.

### Notes

- We need 2 different workflow files, because each runs in a different context with different permissions. See [GitHub Actions docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run) and ["Preview in LiveCodes" docs](https://github.com/live-codes/preview-in-livecodes). This is [demo repo](https://github.com/hatemhosny/preview-in-livecodes-demo).
- The workflow files need to be merged to the default branch, before they are able to run. Changes to projects can then be seen with each PR even if the projects themselves are changed.
- You can add as many projects to `.livecodes\` directory. Each JSON file represents a [LiveCodes configuration object](https://livecodes.io/docs/configuration/configuration-object). You have full control of what you want the playgrounds to do.
- When this PR is merged and everything is working well, we can add more projects (e.g. for different frameworks like react, vue (3/2), svelte, solid, etc) or different ninja-keys data configuration.

Edit:
- Currently the build artifacts `bundle/all.js` and `types/index.d.ts` are converted to data urls and added in the link URL. The resulting ESM module is then used as [import map in the playground](https://livecodes.io/docs/features/module-resolution#custom-module-resolution) to allow importing from `'konnors-ninja-keys'` without having to publish it. So [minifying the build](https://github.com/KonnorRogers/konnors-ninja-keys/issues/23#issuecomment-2571553446) can help make this more performant.

Please let me know if you have any questions or comments.
Thank you.

Closes #23 